### PR TITLE
fix: Product Validation 쿼리 테이블명과 컬럼명 소문자로 변경

### DIFF
--- a/src/main/java/flab/nutridiary/product/repository/ProductCrudRepository.java
+++ b/src/main/java/flab/nutridiary/product/repository/ProductCrudRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.repository.CrudRepository;
 
 public interface ProductCrudRepository extends CrudRepository<Product, Long> {
 
-    @Query("select count(*) from PRODUCT where PRODUCT_NORMALIZED_NAME = :normalizedName")
+    @Query("select count(*) from product where product_normalized_name = :normalizedName")
     Integer isExistDuplicatedProductByNormalizedName(String normalizedName);
 }


### PR DESCRIPTION
- prod 서버의 mysql에서 대문자 테이블명과 소문자 테이블명 구분으로 에러발생
close #54 